### PR TITLE
Add 2.13.1 as a noarch build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "marshmallow" %}
-{% set version = "3.0.0rc1" %}
-{% set sha256 = "7adba78acbce1a812185ab8139d2c80223387d751f8c558d53eceb8aecf7cae5" %}
+{% set version = "2.13.1" %}
+{% set sha256 = "cf7e35ddfe8b18f8de3058fffc621921c79bb07455ad3084bfbf64caca766711" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
I am the maintainer of flask-rest-jsonapi-feedstock and that package has a hard dependency on marshmallow 2.13.1.

Currently, the build is failing because 2.13.1 is not built with noarch, this PR fixes that problem.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->