### PR TITLE
Removing itghisi from maintainers list

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,6 @@ extra:
     - hajapy
     - rth
     - frol
-    - igortg
     - carlodri
     - mariusvniekerk
     - xylar


### PR DESCRIPTION
It's a long time since I last used this package. And I guess it has enough maintainers to keep it healthy. I'm pulling out.